### PR TITLE
Support non versioned rebar lock files

### DIFF
--- a/rebar.lock.script
+++ b/rebar.lock.script
@@ -2,8 +2,14 @@ case filelib:is_file("rebar.lock") of
     false ->
         CONFIG;
     true ->
-        [{"1.1.0", Deps},[{pkg_hash, Hashes}]] = CONFIG,
-        {_, Deps} = lists:keyfind("1.1.0", 1, CONFIG),
+        {Deps, Hashes} =
+            case CONFIG of
+                [{"1.1.0", CDeps},[{pkg_hash, CHashes}]] ->
+                    {CDeps, CHashes};
+                [CDeps] ->
+                    %% Support old style rebar.lock files
+                    {CDeps, []}
+            end,
         {ok, VerneMQRebarLockTerms} = file:consult("vernemq.rebar.lock"),
         [{"1.1.0", VerneMQDeps}, [{pkg_hash, VerneMQHashes}]] = VerneMQRebarLockTerms,
         {UpdatedDeps, UpdatedHashes} =

--- a/run.sh
+++ b/run.sh
@@ -8,4 +8,5 @@ rebar3 compile
 find -L _build/default/lib -regex ".*\/\(plugins\|ebin\|priv\)\/.*" -print0 | tar -czvf bundle.tar.gz --null -T -
 mkdir -p bundler
 mv bundle.tar.gz bundler/.
+echo "Serving bundle on http://${HTTP_ADDRESS:-0.0.0.0}:${HTTP_PORT:-8080}/bundle.tar.gz"
 erl -s inets -eval "{ok, _} = inets:start(httpd, [{port, ${HTTP_PORT:-8080}}, {document_root, \"$PWD/bundler\"}, {bind_address, \"${HTTP_ADDRESS:-0.0.0.0}\"}, {server_name, \"vmq_plugin_bundler\"}, {server_root, \"$PWD/bundler\"}])." -noshell -noinput


### PR DESCRIPTION
With this I'm able to build both:

```
docker run -p 8080:8080 -e BUNDLER_CONFIG="{plugins, [{rebar3_cargo, {git, \"git://github.com/benoitc/rebar3_cargo\", {ref, \"379115f\"}}}]}. {deps, [{vmq_k8s, {git, \"git://github.com/vernemq/vmq-operator\", {branch, \"master\"}}}]}. mybuilder"
```

and 

```
docker run -p 8080:8080 -e BUNDLER_CONFIG="{deps, [{vernemq_demo_plugin, {git, \"git://github.com/larshesel/vernemq_demo_plugin.git\", {branch, \"test-builder\"}}}]}." mybuilder
```

So this fixes #1 